### PR TITLE
Use interlocked when updating the seq no.

### DIFF
--- a/src/OpenTelemetry.OpAMPClient/OpAMPClient.cs
+++ b/src/OpenTelemetry.OpAMPClient/OpAMPClient.cs
@@ -65,7 +65,7 @@ public class OpAMPClient
         var message = new AgentToServer()
         {
             InstanceUid = this.instanceUid,
-            SequenceNum = this.sequenceNum++,
+            SequenceNum = this.IncrementSequenceNum(),
         };
 
         message.AgentDescription = new AgentDescription();
@@ -131,4 +131,6 @@ public class OpAMPClient
 
         await this.transport.SendAsync(message, this.token).ConfigureAwait(false);
     }
+
+    private ulong IncrementSequenceNum() => Interlocked.Increment(ref this.sequenceNum);
 }


### PR DESCRIPTION
Once we have other methods to send messages from the agent to the server, we want to ensure that we handle those in a thread-safe way.
